### PR TITLE
Updation of Github Action client version for Homework Bot 

### DIFF
--- a/.github/workflows/check-homework.yml
+++ b/.github/workflows/check-homework.yml
@@ -141,7 +141,7 @@ jobs:
         cd checker
         check_homework -v -i definitions/homework.yml -o results.md
     - name: Upload result md file
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: homework_result
         path: checker/results.md


### PR DESCRIPTION
The guidelines to follow homework submissions for [Full C++ 17 course](https://www.youtube.com/playlist?list=PLwhKb0RIaIS1sJkejUmWj-0lk7v_xgCuT) has been detailed in [Submitting Homeworks](https://youtu.be/Nl0u04XgxGQ?si=3dDhmYAIbELuSaq1) video. But, due to deprecated version of `actions/upload-artifact: v2`, Homework Bot raises error as below

![image](https://github.com/user-attachments/assets/0848ab9c-5934-48b9-9dae-102dcd6a4fb5)

This PR has updated the old deprecated versions of actions/upload-artifact to v4 from v2. In addition, following libraries were updated to newer versions.

- peter-evans/find-comment@v2 -> peter-evans/find-comment@v3
- peter-evans/create-or-update-comment@v -> peter-evans/create-or-update-comment@v4
- actions/checkout@v3 -> actions/checkout@v4
- actions/setup-python@v2 -> actions/setup-python@v5
- actions/upload-artifact@v2 -> actions/upload-artifact@v4
- actions/download-artifact@v2 ->actions/download-artifact@v4

After making these changes, the CI jobs have run successfully.

![image](https://github.com/user-attachments/assets/b75374dc-aebf-42a5-ad46-ddcb04dfd3f0)

Note, line 57 has been changed to forked repository (dheerubhai-101/ci-jobs) for testing.
<img width="628" alt="image" src="https://github.com/user-attachments/assets/75a3e01e-a789-404e-831a-2e64c7b22e84" />

Kindly check and it let me know if we can merge this for future users to utilize homework bot for submissions.